### PR TITLE
Decrease default fade-in time for Product Image

### DIFF
--- a/dist/components/ProductImage.vue
+++ b/dist/components/ProductImage.vue
@@ -38,7 +38,7 @@ export default {
     },
     fadeIn: {
       type: Number,
-      default: 1
+      default: 0.38
     }
   },
   computed: {

--- a/src/components/ProductImage.vue
+++ b/src/components/ProductImage.vue
@@ -38,7 +38,7 @@ export default {
     },
     fadeIn: {
       type: Number,
-      default: 1
+      default: 0.38
     }
   },
   computed: {


### PR DESCRIPTION
- Improves perceived performance (site feels faster) by decreasing fade-in time by 62%
- Demo site: [here](https://5de6cc85f9831d01e455b312--stupefied-swartz-bd2b1c.netlify.com/)
- Addresses [NC-208](https://nacelle.atlassian.net/browse/NC-208)