### PR TITLE
[HOTFIX] Decrease default fade-in time for Product Image

### DIFF
--- a/dist/components/ProductImage.vue
+++ b/dist/components/ProductImage.vue
@@ -38,7 +38,7 @@ export default {
     },
     fadeIn: {
       type: Number,
-      default: 0.38
+      default: 0.3
     }
   },
   computed: {

--- a/src/components/ProductImage.vue
+++ b/src/components/ProductImage.vue
@@ -38,7 +38,7 @@ export default {
     },
     fadeIn: {
       type: Number,
-      default: 0.38
+      default: 0.3
     }
   },
   computed: {


### PR DESCRIPTION
### What This Is
- A hotfix to immediately improve the perceived performance of downstream sites (including the starship demo)
- Same as https://github.com/getnacelle/nacelle-vue-components/pull/96 but submitted to the `dev` branch and with a slightly lower default fade-in time
- Addresses [NC-208](https://nacelle.atlassian.net/browse/NC-208)

### What This Isn't
- A comprehensive solution to problems with inconsistent transitions caused by not listening for an image's loading state
  - Planning to address that in a fix related to [NC-289](https://nacelle.atlassian.net/browse/NC-289)