### PR TITLE
Apply transitions to product images only after those images have loaded

### DIFF
--- a/dist/components/ProductImage.vue
+++ b/dist/components/ProductImage.vue
@@ -1,45 +1,46 @@
 <template>
   <div
+    class="product-image nacelle"
+    ref="img-card"
     v-observe-visibility="{
       callback: visibilityChanged,
       once: true
     }"
-    class="product-image nacelle"
-    ref="img-card"
   >
     <picture>
       <source
         v-if="visibility && cloudinaryCanAutoFormat && validImage"
         :srcset="optimizeSource({ url: source, format: 'auto' })"
-        @error="fallback"
+        v-on:loadend="onLoaded"
       />
       <source
         v-if="visibility && reformat && validImage"
         :srcset="optimizeSource({ url: source, format: 'webp' })"
         type="image/webp"
-        @error="fallback"
       />
       <source
         v-if="visibility && reformat && validImage"
         :srcset="optimizeSource({ url: source, format: 'jpg' })"
         type="image/jpeg"
-        @error="fallback"
       />
       <img
         v-if="visibility"
+        v-on:loadend="onLoaded"
+        v-bind:class="{ loaded }"
         ref="product-image"
         :src="source"
         :alt="alt"
         :width="width"
+        :height="height"
         :style="cssVars"
         @error="fallback"
       />
+      <img v-else-if="!visibility" :src="blankImage" />
     </picture>
   </div>
 </template>
 
 <script>
-import Vue from 'vue'
 import imageOptimize from '../mixins/imageOptimize'
 import imageVisibility from '../mixins/imageVisibility'
 
@@ -53,9 +54,6 @@ export default {
     alt: {
       type: String,
       default: 'Featured Product Image'
-    },
-    width: {
-      type: Number
     },
     fadeIn: {
       type: Number,
@@ -84,10 +82,12 @@ export default {
 .product-image,
 img {
   width: 100%;
-  animation: fadein var(--fade-in-time);
-  -moz-animation: fadein var(--fade-in-time); /* Firefox */
-  -webkit-animation: fadein var(--fade-in-time); /* Safari and Chrome */
-  -o-animation: fadein var(--fade-in-time); /* Opera */
+  .loaded {
+    animation: fadein var(--fade-in-time);
+    -moz-animation: fadein var(--fade-in-time); /* Firefox */
+    -webkit-animation: fadein var(--fade-in-time); /* Safari and Chrome */
+    -o-animation: fadein var(--fade-in-time); /* Opera */
+  }
 }
 @keyframes fadein {
   from {

--- a/dist/mixins/imageOptimize.js
+++ b/dist/mixins/imageOptimize.js
@@ -26,14 +26,22 @@ export default {
     byDominantColor: {
       type: Boolean,
       default: false
+    },
+    width: {
+      type: Number
+    },
+    height: {
+      type: Number
     }
   },
   data() {
     return {
+      blankImage: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 5'%3E%3C/svg%3E",
       blurred: null,
       containerWidth: null,
       containerHeight: null,
       containerPosition: null,
+      loaded: false,
       originCDN: null,
       validImage: true
     }
@@ -56,7 +64,13 @@ export default {
       return `https://res.cloudinary.com/${this.cloudinaryCloudName}/image/fetch/`
     },
     fallbackImage() {
-      return 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'
+      return this.blankImage
+    },
+    loading() {
+      return !this.loaded
+    },
+    placeholderImg(w, h) {
+      return `data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}"%3E%3C/svg%3E`
     },
     shopifyPathPrefix() {
       const path = this.getMetafield('cdn', 'shopify-path-prefix') || 'https://cdn.shopify.com/s/files/'
@@ -90,6 +104,9 @@ export default {
           this.$refs[this.containerRef]
         ).position
       }
+    },
+    onLoaded() {
+      this.loaded = true
     },
     fallback() {
       this.validImage = false
@@ -223,10 +240,4 @@ export default {
       return false
     }
   }
-  // mounted() {
-  //   this.calculateContainer()
-  // },
-  // updated() {
-  //   this.calculateContainer()
-  // }
 }

--- a/src/components/ProductImage.vue
+++ b/src/components/ProductImage.vue
@@ -1,45 +1,46 @@
 <template>
   <div
+    class="product-image nacelle"
+    ref="img-card"
     v-observe-visibility="{
       callback: visibilityChanged,
       once: true
     }"
-    class="product-image nacelle"
-    ref="img-card"
   >
     <picture>
       <source
         v-if="visibility && cloudinaryCanAutoFormat && validImage"
         :srcset="optimizeSource({ url: source, format: 'auto' })"
-        @error="fallback"
+        v-on:loadend="onLoaded"
       />
       <source
         v-if="visibility && reformat && validImage"
         :srcset="optimizeSource({ url: source, format: 'webp' })"
         type="image/webp"
-        @error="fallback"
       />
       <source
         v-if="visibility && reformat && validImage"
         :srcset="optimizeSource({ url: source, format: 'jpg' })"
         type="image/jpeg"
-        @error="fallback"
       />
       <img
         v-if="visibility"
+        v-on:loadend="onLoaded"
+        v-bind:class="{ loaded }"
         ref="product-image"
         :src="source"
         :alt="alt"
         :width="width"
+        :height="height"
         :style="cssVars"
         @error="fallback"
       />
+      <img v-else-if="!visibility" :src="blankImage" />
     </picture>
   </div>
 </template>
 
 <script>
-import Vue from 'vue'
 import imageOptimize from '../mixins/imageOptimize'
 import imageVisibility from '../mixins/imageVisibility'
 
@@ -53,9 +54,6 @@ export default {
     alt: {
       type: String,
       default: 'Featured Product Image'
-    },
-    width: {
-      type: Number
     },
     fadeIn: {
       type: Number,
@@ -84,10 +82,12 @@ export default {
 .product-image,
 img {
   width: 100%;
-  animation: fadein var(--fade-in-time);
-  -moz-animation: fadein var(--fade-in-time); /* Firefox */
-  -webkit-animation: fadein var(--fade-in-time); /* Safari and Chrome */
-  -o-animation: fadein var(--fade-in-time); /* Opera */
+  .loaded {
+    animation: fadein var(--fade-in-time);
+    -moz-animation: fadein var(--fade-in-time); /* Firefox */
+    -webkit-animation: fadein var(--fade-in-time); /* Safari and Chrome */
+    -o-animation: fadein var(--fade-in-time); /* Opera */
+  }
 }
 @keyframes fadein {
   from {

--- a/src/mixins/imageOptimize.js
+++ b/src/mixins/imageOptimize.js
@@ -26,14 +26,22 @@ export default {
     byDominantColor: {
       type: Boolean,
       default: false
+    },
+    width: {
+      type: Number
+    },
+    height: {
+      type: Number
     }
   },
   data() {
     return {
+      blankImage: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 5'%3E%3C/svg%3E",
       blurred: null,
       containerWidth: null,
       containerHeight: null,
       containerPosition: null,
+      loaded: false,
       originCDN: null,
       validImage: true
     }
@@ -56,7 +64,13 @@ export default {
       return `https://res.cloudinary.com/${this.cloudinaryCloudName}/image/fetch/`
     },
     fallbackImage() {
-      return 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'
+      return this.blankImage
+    },
+    loading() {
+      return !this.loaded
+    },
+    placeholderImg(w, h) {
+      return `data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}"%3E%3C/svg%3E`
     },
     shopifyPathPrefix() {
       const path = this.getMetafield('cdn', 'shopify-path-prefix') || 'https://cdn.shopify.com/s/files/'
@@ -90,6 +104,9 @@ export default {
           this.$refs[this.containerRef]
         ).position
       }
+    },
+    onLoaded() {
+      this.loaded = true
     },
     fallback() {
       this.validImage = false
@@ -223,10 +240,4 @@ export default {
       return false
     }
   }
-  // mounted() {
-  //   this.calculateContainer()
-  // },
-  // updated() {
-  //   this.calculateContainer()
-  // }
 }


### PR DESCRIPTION
### What This Does
Addresses [NC-289](https://nacelle.atlassian.net/browse/NC-289).

For the `ProductImage` component, this displays a (blank) placeholder image until the product image is fully loaded. Once the image has loaded, then the CSS transition (fade-in) is applied.

This fixes an issue in which CSS transitions were being effectively bypassed if the time it took the image to load exceeded the perceptible duration of the CSS transition.

### Demo Site
**Diff**: https://5df83ec09109d317149b4c75--stupefied-swartz-bd2b1c.netlify.com/

In the demo site, you should be able to scroll through the `/shop` or collections and have images fade in after they have loaded. I think it feels a bit smoother this way.