### PR TITLE
Fix Product Card Inputs, CSS Bug, & Footer Copyright Year

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -187,6 +187,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-width: 300px;
 }
 
 .product-card-details /deep/ a {

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -10,9 +10,7 @@
       <product-price :price="product.priceRange.max" />
     </div>
     <div v-if="product && product.id" class="product-card-actions">
-      <quantity-selector
-        :quantity.sync="quantity"
-      />
+      <quantity-selector :quantity.sync="quantity" />
       <product-add-to-cart-button
         v-if="showAddToCart == true"
         :product="product"
@@ -160,9 +158,9 @@ export default {
     },
     onlyOneOption() {
       if (
-        this.product.options &&
-        this.product.options.length == 1 &&
-        this.product.options[0].values.length == 1
+        this.allOptions &&
+        this.allOptions.length == 1 &&
+        this.allOptions[0].values.length == 1
       ) {
         return true
       } else {

--- a/src/components/ProductVariantSelect.vue
+++ b/src/components/ProductVariantSelect.vue
@@ -19,9 +19,7 @@
             showQuantitySelect
         "
       >
-        <quantity-selector
-          :quantity.sync="quantity"
-        />
+        <quantity-selector :quantity.sync="quantity" />
       </div>
       <div class="column auto">
         <product-add-to-cart-button
@@ -55,7 +53,7 @@ export default {
       default: true
     }
   },
-  data () {
+  data() {
     return {
       quantity: 0
     }
@@ -70,7 +68,7 @@ export default {
     showProductOptions() {
       return (
         Array.isArray(this.allOptions) &&
-        this.allOptions.length > 1 &&
+        this.allOptions.length >= 1 &&
         this.allOptions[0].values.length > 1 &&
         this.product.availableForSale
       )

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -7,7 +7,9 @@
           <strong>{{ name }}</strong>
         </nuxt-link>
       </div>
-      <div class="column is-12 has-text-centered">© NACELLE 2019</div>
+      <div class="column is-12 has-text-centered">
+        © NACELLE {{ currentYear }}
+      </div>
       <!-- TEMPORARY FOOTER END -->
 
       <!-- <div class="columns is-multiline is-marginless">
@@ -42,7 +44,7 @@
           </ul>
         </div>
 
-        <div class="column is-12 has-text-centered">© NACELLE 2019</div>
+        <div class="column is-12 has-text-centered">© NACELLE {{ currentYear }}</div>
       </div>-->
     </div>
   </div>
@@ -52,6 +54,11 @@
 import { mapState, mapGetters } from 'vuex'
 
 export default {
+  data() {
+    return {
+      currentYear: new Date().getFullYear()
+    }
+  },
   computed: {
     ...mapState('space', ['id', 'name', 'linklists']),
     ...mapGetters('space', ['getLinks']),


### PR DESCRIPTION
### What Does This Do?
- In `ProductCard.vue`:
  - Use the `allOptions` computed property instead of `product.options`
    - 46c5c94 fixes [NC-702](https://nacelle.atlassian.net/browse/NC-702) by making a product with only one option say "Add to Cart" instead of "Select Options"
    - `options` is not (/ no longer?) a field in the `product` object
  - Set a `min-width` on the `product-card-actions` container
    - 86358eb fixes [NC-762](https://nacelle.atlassian.net/browse/NC-762) by making the `product-card-actions` container unable to shrink to a point that it obscures the increment / decrement buttons
- In `ProductVariantSelect.vue`:
  - Correctly checks that the `allOptions` array exists and contains entries 
    - cf76569 fixes [NC-703](https://nacelle.atlassian.net/browse/NC-703) by making a product with options show the options select interface on the PDP
    - The previous check for array entries (`length > 1`) was too strict
#### Bonus!
- In `SiteFooter.vue`:
  - 7ecb772 replaces the static year value in copyright section of footer with dynamic value from current date ([NC-779](https://nacelle.atlassian.net/browse/NC-779))

### Demo Site
With Starship Furniture: https://5e3af644c4b0ceb107b326c6--boring-hoover-57714c.netlify.com